### PR TITLE
Fix letterboxd rating export from html

### DIFF
--- a/letterboxd-export.js
+++ b/letterboxd-export.js
@@ -45,11 +45,16 @@ const handleLetterBoxdResponse = ({ $ }) => {
     const $li = $(el);
     const $img = $("img.image", $li);
     const $poster = $(".film-poster", $li);
+    const $ratingEl= $(".poster-viewingdata > .rating", $li);
 
     const letterboxdId = parseInt($poster.data("filmId"));
-    const letterboxdRating = parseInt($li.data("ownerRating"));
-    const title = $img.attr("alt");
 
+    let letterboxdRating = 0;
+    if($ratingEl.prop('name') !== undefined){
+        const ratingStr = $ratingEl.attr('class')
+        letterboxdRating = parseInt(ratingStr.substring(ratingStr.lastIndexOf('-') + 1));
+    }
+    const title = $img.attr("alt");
     const found = movies.find({ letterboxdId }).value();
 
     if (found) {
@@ -57,7 +62,7 @@ const handleLetterBoxdResponse = ({ $ }) => {
         letterboxdRating
       };
 
-      if (tasteStatus !== null) {
+      if (TASTE_DEFAULT_STATUS !== null) {
         updatedObj.tasteStatus = !!TASTE_DEFAULT_STATUS;
       }
 

--- a/taste-import.js
+++ b/taste-import.js
@@ -32,6 +32,10 @@ async.eachLimit(
   movies,
   REQUEST_LIMIT,
   async ({ letterboxdId: id, title, letterboxdRating }) => {
+    if(letterboxdRating === 0){
+        console.log(`NOT RATED: ${title}`);
+        return false;
+    }
     const searchResponse = await got(
       `https://www.taste.io/api/movies/search?q=${encodeURIComponent(title)}`,
       {


### PR DESCRIPTION
This PR resolves #3, since the scraping of the Letterboxd movie rating has changed, and the rating number now has to be scraped from the css class name of the  `<p>` element with class `rating-{RATING}`. Also if there are unrated Movies in your Letterboxd Profile (rating: 0) they are not added to TasteIO, since you cant add a Movie without a rating to your profile. 